### PR TITLE
Add Kuzzle to Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ ToC
 
 ## Middleware
 
+* **[Kuzzle ★ 502 ⧗ 0](https://github.com/kuzzleio/kuzzle)** - An open-source backend with advanced features like real-time pub/sub or geofencing and a multiprotocol interface that supports MQTT, LoRaWAN and more. [(Website)](https://kuzzle.io/solutions/technologies/iot-backend/)
 * [Kaa ★ 234 ⧗ 0](https://github.com/kaaproject/kaa) - Kaa open-source middleware platform for building, managing, and integrating connected products with the Internet of Everything.
 * [Meact ★ 6 ⧗ 43](https://github.com/bkupidura/meact) - task is to get metric from external stuff, write it to  and perform various action.
 * [OpenIoT ★ 205 ⧗ 0](https://github.com/OpenIotOrg/openiot) - The OpenIoT middleware infrastructure will support flexible configuration and deployment of algorithms for collection


### PR DESCRIPTION
I just add Kuzzle to the list of IoT middleware.  
I put it on top because it was the only actively maintained project with SiteWhere.  