### PR TITLE
Add Simple IoT — single-binary IoT platform (Spring Boot 4 + Vue 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [BitSCADA ★ 0 ⧗ 0](https://github.com/larionovavi-stack/bitscada) - Complete industrial SCADA/HMI system that runs from a single HTML file. Supports IEC 61850 (MMS, GOOSE, SV), OPC UA, Modbus TCP, MQTT. 53 function blocks, 65 graphic elements, Python gateway for real PLC/RTU/IED connections. Zero installation — any browser.
 * [Fuxa SCADA/HMI/Dashboard ★ 2115 ⧗ 632](https://github.com/frangoteam/FUXA) - FUXA is a web-based Process Visualization (SCADA/HMI/Dashboard) software. With FUXA you can create modern process visualizations/dashboards with individual designs for your machines/IOT application with real-time data display. Supports MQTT, OPC-UA, Modbus RTU/TCP, Siemens S7 Protocol, BACnet IP, Ethernet/IP (Allen Bradley), WebAPI
 * [awtSCADA](https://github.com/larionovavi-stack/awtscada) - Industrial SCADA/HMI system that runs from a single HTML file in any browser. Supports IEC 61850, OPC UA, Modbus TCP. 53 function blocks, 65 graphic elements. No installation required.
+* [Simple IoT](https://github.com/dingdaoyi/simple-iot) - Single-binary, self-hosted IoT platform built with Spring Boot 4 + Vue 3. Built-in MQTT broker, visual rule engine, hot-loaded Java/JS/Groovy/Lua protocol scripts, InfluxDB 3 time-series storage. One-command deploy on a 2 GB VPS.
 
 ## IoT Clouds
 


### PR DESCRIPTION
Adds [Simple IoT](https://github.com/dingdaoyi/simple-iot) under **Platform** section.\n\nSingle-binary, self-hosted IoT platform built with Spring Boot 4 + Vue 3:\n- Built-in MQTT broker (mica-mqtt)\n- Visual drag-and-drop rule engine\n- Hot-loaded Java / JavaScript / Groovy / Lua protocol scripts\n- InfluxDB 3 time-series storage\n- One-command Docker Compose deploy on a 2 GB VPS\n\nLive demo: http://122.51.129.91 — Docs: https://dingdaoyi.github.io/simple-iot/\n\nEntry follows the contributing.md format (capitalized title, dash-comment-period, end of category).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Simple IoT" to the curated project list in the README, featuring Spring Boot 4 + Vue 3 with built-in MQTT broker, rule engine, and one-command deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->