### PR TITLE
Add ZHAC project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Layered architecture of JTAG interface and TAP support
 * [Node-RED](https://github.com/node-red/node-red) - Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways.
 * [hkontroller](https://github.com/hkontrol/hkontroller) - Apple HomeKit Controller implemented in Go programming language.
 * [hkmobile](https://github.com/hkontrol/hkmobile) - Apple HomeKit Controller for Android.
+* [ZHAC](https://github.com/zhac-project/zhac-platform) - A dual-chip ESP32-P4 + ESP32-S3 Zigbee home automation controller with a Lua rule engine, local web UI, and MQTT gateway.
 
 ## IDE
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added ZHAC to the Home Automation list, including repository details and a summary of its Zigbee controller, Lua rule engine, web interface, and MQTT gateway capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->