### PR TITLE
Add DeviceChain to the Platform section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ This libraries allows to work with the GPIO port for various boards like Raspber
 * [Fuxa SCADA/HMI/Dashboard ★ 2115 ⧗ 632](https://github.com/frangoteam/FUXA) - FUXA is a web-based Process Visualization (SCADA/HMI/Dashboard) software. With FUXA you can create modern process visualizations/dashboards with individual designs for your machines/IOT application with real-time data display. Supports MQTT, OPC-UA, Modbus RTU/TCP, Siemens S7 Protocol, BACnet IP, Ethernet/IP (Allen Bradley), WebAPI
 * [awtSCADA](https://github.com/larionovavi-stack/awtscada) - Industrial SCADA/HMI system that runs from a single HTML file in any browser. Supports IEC 61850, OPC UA, Modbus TCP. 53 function blocks, 65 graphic elements. No installation required.
 * [Simple IoT](https://github.com/dingdaoyi/simple-iot) - Single-binary, self-hosted IoT platform built with Spring Boot 4 + Vue 3. Built-in MQTT broker, visual rule engine, hot-loaded Java/JS/Groovy/Lua protocol scripts, InfluxDB 3 time-series storage. One-command deploy on a 2 GB VPS.
+* [DeviceChain](https://github.com/devicechain-io/devicechain) - Apache-2.0 self-hosted IoT platform written in Go and React. Multi-tenant microservices on Kubernetes: MQTT/Sparkplug B/LwM2M ingest, TimescaleDB time-series storage, a CEL-based rule engine with alarms and outbound connectors, versioned dashboards, and GraphQL APIs. [(Docs)](https://docs.devicechain.io)
 
 ## IoT Clouds
 


### PR DESCRIPTION
Adds [DeviceChain](https://github.com/devicechain-io/devicechain) to **Platform** — an Apache-2.0, self-hosted IoT platform written in Go and React.

Multi-tenant microservices on Kubernetes: MQTT / Sparkplug B / LwM2M ingest, TimescaleDB time-series storage, a CEL-based rule engine with alarms and outbound connectors, versioned dashboards, and per-area GraphQL APIs.

- Docs: https://docs.devicechain.io
- License: Apache-2.0

Disclosure: I'm the author. Happy to adjust the wording or placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DeviceChain to the Platform section, including an overview of its architecture, supported protocols, storage, rule engine, dashboards, and GraphQL APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->