### PR TITLE
Add ble-scale-sync to Home Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Layered architecture of JTAG interface and TAP support
 * [hkontroller](https://github.com/hkontrol/hkontroller) - Apple HomeKit Controller implemented in Go programming language.
 * [hkmobile](https://github.com/hkontrol/hkmobile) - Apple HomeKit Controller for Android.
 * [ZHAC](https://github.com/zhac-project/zhac-platform) - A dual-chip ESP32-P4 + ESP32-S3 Zigbee home automation controller with a Lua rule engine, local web UI, and MQTT gateway.
+* [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - Cross-platform Node.js service that reads BLE smart scales, calculates body composition, and exports readings to MQTT with Home Assistant auto-discovery, InfluxDB, Garmin Connect, and webhooks.
 
 ## IDE
 


### PR DESCRIPTION
Adds [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) as the last item under Home Automation.

A cross-platform Node.js service that reads weight and body composition from 25+ Bluetooth Low Energy smart scale brands (Xiaomi, Renpho, Beurer, Eufy, QN, Yunmai, Arboleaf and others), computes the full BIA metric set locally, and exports to MQTT with Home Assistant auto-discovery, InfluxDB, Garmin Connect, Strava, Intervals.icu, webhooks, ntfy and local CSV/JSONL. No vendor cloud, no phone app.

Runs headless on a Raspberry Pi, Linux, macOS or Windows, and can also collect readings through an ESPHome BLE proxy or an ESP32 MQTT proxy when the server is out of Bluetooth range.

- GPL-3.0, 153 stars, actively developed (v1.23.0, 2026-08-19)
- Docs: https://blescalesync.dev
- Docker images for amd64, arm64 and armv7

Disclosure: I am the author of the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ble-scale-sync` to the Home Automation project list.
  * Documented support for smart-scale readings, body composition calculations, and integrations with MQTT, Home Assistant, InfluxDB, Garmin Connect, and webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->