### PR TITLE
Add CosmoEdge to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ for embedded systems (IoT in mind).
 * [Machinery ★ 174 ⧗ 0](https://github.com/kerberos-io/machinery) - is a low-budget video surveillance solution, that uses computer vision algorithms to detect changes, and that can trigger other devices.
 * [TensorFlow for Raspberry Pi ★ 317 ⧗ 0](https://github.com/samjabrahams/tensorflow-on-raspberry-pi) - step-by-step instructions for installing TensorFlow from source using Bazel (which is also compiled from-scratch), as well as pre-built TensorFlow binaries.
 * [Genesis 2](https://github.com/larionovavi-stack/genesis2-cascade-moe) - Cascade MoE neural network for IoT edge deployments. CPU-only inference (18ms), no GPU required, patented architecture with zero catastrophic forgetting.
+* [CosmoEdge](https://github.com/cosmo-wander-ai/cosmo-edge) - Production-oriented C++ edge video AI engine that connects RTSP streams to CV/VLM inference, visual orchestration, alarms, and MQTT/webhook events on Sophon and Rockchip NPUs.
 
 ## Analytics
 


### PR DESCRIPTION
Adds CosmoEdge to the AI section.

CosmoEdge is a production-oriented Apache-2.0 C++ engine for running video AI workflows locally on Linux edge devices and NPUs. It combines RTSP ingestion, CV/VLM inference, visual orchestration, alarms, and MQTT/webhook integration.

The project is actively maintained and provides an x86 quick-start path in addition to Sophon and Rockchip NPU targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CosmoEdge to the AI resources list, highlighting edge video AI, RTSP, computer vision, orchestration, alarm, MQTT, and webhook capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->